### PR TITLE
Support more numeric prefixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +514,7 @@ name = "lyricsrs"
 version = "0.1.0"
 dependencies = [
  "lofty",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -739,6 +749,35 @@ checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "lyricsrs"
 
 [dependencies]
 lofty = "0.20.1"
+regex = "1.10.5"
 reqwest = { version = "0.12.5", features = ["json", "blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use lofty::file::AudioFile;
 use lofty::probe::Probe;
+use regex::Regex;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicUsize;
@@ -120,16 +121,17 @@ async fn parse_song_path(file_path: &Path, music_dir: &Path, successful_count: A
 }
 
 fn remove_numbered_prefix(s: &str) -> String {
-    // Find the index of the first dot
-    if let Some(index) = s.find('.') {
-        // Check if characters before the dot are digits
-        if s[..index].chars().all(|c| c.is_digit(10)) {
-            // Return substring after the dot
-            return s[index + 1..].trim().to_string();
-        }
-    }
-    // If no valid prefix found, return the original string
-    s.to_string()
+    let re = Regex::new(r"^(\d*\s?[\-\._\s]+)(.+)$").unwrap();
+    let matches = re.captures(s);
+    let name = match matches {
+        Some(v) => match v.get(2) {
+            Some(n) => n.as_str(),
+            None => s,
+        },
+        None => s,
+    };
+
+    return name.to_string();
 }
 
 fn get_audio_duration(file_path: &PathBuf) -> Duration {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,12 +2,18 @@ use std::path::PathBuf;
 
 use tokio::fs;
 
-pub const SONGS: [&str; 5] = [
+pub const SONGS: [&str; 11] = [
     "Taylor Swift/THE TORTURED POETS DEPARTMENT: THE ANTHOLOGY/1. Fortnight (Ft. Post Malone).flac",
     "Taylor Swift/THE TORTURED POETS DEPARTMENT: THE ANTHOLOGY/2. The Tortured Poets Department.mp3",
     "Taylor Swift/THE TORTURED POETS DEPARTMENT: THE ANTHOLOGY/3. My Boy Only Breaks His Favorite Toys.m4a",
     "Taylor Swift/reputation/2. End Game.flac",
     "Lou Reed/The Best of Lou Reed/8. Perfect Day.m4a",
+    "Heilung/Drif/01 Asja.flac",
+    "Heilung/Drif/02 - Anoana.flac",
+    "LINKIN PARK/Hybrid Theory/09-A Place for my Head.mp3",
+    "LINKIN PARK/LIVING THINGS/6.CASTLE OF GLASS.flac",
+    "Our Lady Peace/Clumsy/5_4AM.mp3",
+    "Our Lady Peace/Spiritual Machines/04 _ In Repair.mp3",
 ];
 
 pub const BASE_DIR: &str = "Music";


### PR DESCRIPTION
Instead of requiring numeric prefixes to be in the form `<number>.<title>`, allow more formats commonly seen. Some examples of supported formats now:

- `40 Track Title`
- `03-Track Title`
- `4 - Track Title`
- `102_Track Title`
- `42.Track Title`