### PR TITLE
Do not overwrite existing lyrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
-### Lyrics getter
+# Lyrics getter
 
-Huge thanks to https://github.com/tranxuanthang/lrclib ofc.
+Huge thanks to <https://github.com/tranxuanthang/lrclib> ofc.
 
 Uses lrclib.net to get lyrics for my Jellyfin library. Does /get, if unavailable tried to do /search
 
-Is very much dependant on having the Jellyfin suggested music library structure. (Artist/Album/Song).
+Is very much dependent on having the Jellyfin suggested music library structure. (Artist/Album/Song).
 
 To run go `lyricsrs <music_directory>` or clone the repo and `cargo run <music_directory>`.
 
-Will overwrite any .lrc files you already have with the existing name.
+Will not overwrite any .lrc files you already have with the existing name by default.
 
-Only does synced lyrics because they are cool.
+Only does synced lyrics by default because they are cool.
 
+## Flags
+
+`lyricsrs` accepts command-line flags to change its behaviour:
+
+- `--overwrite`: Overwrite lyrics files, if present, with lyrics from lrclib
+- `--allow-plain`: Allow writing plain lyrics if no synced lyrics are available

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,11 +13,11 @@ pub const SONGS: [&str; 11] = [
     "Heilung/Drif/02 - Anoana.flac",
     "LINKIN PARK/Hybrid Theory/09-A Place for my Head.mp3",
     "LINKIN PARK/LIVING THINGS/6.CASTLE OF GLASS.flac",
-    "Our Lady Peace/Clumsy/5_4AM.mp3",
+    "Our Lady Peace/Clumsy/5_4am.mp3",
     "Our Lady Peace/Spiritual Machines/04 _ In Repair.mp3",
 ];
 
-async fn create_files_with_names(output_file: &PathBuf) {
+pub async fn create_files_with_names(output_file: &PathBuf) {
     let dirs = output_file.parent().expect("could not parse dirs");
     let file_name = output_file.file_name().expect("could not parse name");
 
@@ -34,6 +34,7 @@ async fn create_files_with_names(output_file: &PathBuf) {
         "flac" => "tests/data/template.flac",
         "mp3" => "tests/data/template.mp3",
         "m4a" => "tests/data/template.m4a",
+        "lrc" => "tests/data/template.lrc",
         _ => todo!(),
     };
 

--- a/tests/data/template.lrc
+++ b/tests/data/template.lrc
@@ -1,0 +1,4 @@
+[00:36.00] Humppa negala
+[00:38.50] Humppa negala
+[00:39.25] Humppa negala
+[00:41.00] Venismechah

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,56 +6,61 @@ mod common;
 
 #[tokio::test]
 async fn test_cli() {
-    // TempDir deletes the created directory when the struct is dropped. Call TempDir::leak() to
-    // keep it around for debugging purposes.
-    let tmpdir = &TempDir::new().unwrap();
-    common::setup(tmpdir).await;
-
-    let target_dir = env::var("CARGO_MANIFEST_DIR").expect("could not get target dir");
-
-    let mut path = PathBuf::from(target_dir);
-    path.push("target/release/lyricsrs");
-
-    let output = Command::new(path)
-        .arg(tmpdir.path())
-        .output()
-        .expect("Failed to execute command");
-
-    let stdout_str = String::from_utf8_lossy(&output.stdout);
-    let stderr_str = String::from_utf8_lossy(&output.stderr);
-
-    println!("Exit code: {}", output.status.code().unwrap());
-    println!("STDOUT: {}", stdout_str);
-    println!("STDERR: {}", stderr_str);
-
-    assert!(output.status.success());
-
-    // keep in sync with SONGS in common/mod.rs
-    let to_find = format!(
-        "Successful tasks: {}\nFailed tasks: 0\nTotal tasks: {}",
-        common::SONGS.len(),
-        common::SONGS.len()
-    );
-    assert!(stdout_str.contains(&to_find));
-
-    assert!(common::check_lrcs(tmpdir).await);
+    let args: Vec<&str> = Vec::new();
+    run_test_command(&args, false).await;
 }
 
 #[tokio::test]
 async fn test_cli_plain_lyrics_allowed() {
+    let mut args = Vec::new();
+    args.push("--allow-plain");
+    run_test_command(&args, false).await;
+}
+
+#[tokio::test]
+async fn test_cli_existing_lyrics() {
+    let args: Vec<&str> = Vec::new();
+    run_test_command(&args, true).await;
+}
+
+#[tokio::test]
+async fn test_cli_no_existing_lyrics_with_flag() {
+    let mut args = Vec::new();
+    args.push("--overwrite");
+    run_test_command(&args, false).await;
+}
+
+#[tokio::test]
+async fn test_cli_existing_lyrics_with_flag() {
+    let mut args = Vec::new();
+    args.push("--overwrite");
+    run_test_command(&args, true).await;
+}
+
+// Generic runner for tests that only need CLI flags changed. Optionally will create a LRC file for
+// validating behaviour around lyrics file replacement.
+async fn run_test_command(args: &Vec<&str>, add_lrc: bool) {
     // TempDir deletes the created directory when the struct is dropped. Call TempDir::leak() to
     // keep it around for debugging purposes.
     let tmpdir = &TempDir::new().unwrap();
     common::setup(tmpdir).await;
+
+    if add_lrc {
+        let mut file_name = tmpdir.child(common::SONGS[3]);
+        file_name.set_extension("lrc");
+        common::create_files_with_names(&file_name).await;
+    }
 
     let target_dir = env::var("CARGO_MANIFEST_DIR").expect("could not get target dir");
 
     let mut path = PathBuf::from(target_dir);
     path.push("target/release/lyricsrs");
 
+    let mut cmd_args = Vec::new();
+    cmd_args.clone_from(args);
+    cmd_args.push(tmpdir.path().to_str().unwrap());
     let output = Command::new(path)
-        .arg("--allow-plain")
-        .arg(tmpdir.path())
+        .args(cmd_args)
         .output()
         .expect("Failed to execute command");
 


### PR DESCRIPTION
Instead of overwriting the lyrics file, which may have been locally modified after download, skip processing if the lyrics file is already present.

```
Skipping 06 Vengeance Venom, lyrics file exists: /opt/docker-data/jellyfin/media/music/Leaves' Eyes/King of Kings (Deluxe Version)/06 Vengeance Venom.lrc
[exact_search] requesting: http://lrclib.net/api/get?track_name=09+Haraldskv%C3%A6di&artist_name=Leaves%27+Eyes&album_name=King+of+Kings+%28Deluxe+Version%29&duration=204
```