### PR TITLE
Allow using plain lyrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +149,52 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "core-foundation"
@@ -296,6 +391,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +542,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,11 +620,13 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 name = "lyricsrs"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "lofty",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
+ "temp-dir",
  "tokio",
  "urlencoding",
  "walkdir",
@@ -1034,6 +1143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1191,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "temp-dir"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f227968ec00f0e5322f9b8173c7a0cbcff6181a0a5b28e9892491c286277231"
 
 [[package]]
 name = "tempfile"
@@ -1263,6 +1384,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ name = "lyricsrs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.5.9", features = ["derive"] }
 lofty = "0.20.1"
 regex = "1.10.5"
 reqwest = { version = "0.12.5", features = ["json", "blocking"] }
@@ -17,3 +18,6 @@ serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 urlencoding = "2.1.3"
 walkdir = "2.5.0"
+
+[dev-dependencies]
+temp-dir = "0.1.13"

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,7 +278,7 @@ async fn exact_search(
                                 "[exact_search] no lyrics available {} for song {}",
                                 json_data, clean_song
                             );
-                           String::new()
+                            String::new()
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,7 +278,7 @@ async fn exact_search(
                                 "[exact_search] no lyrics available {} for song {}",
                                 json_data, clean_song
                             );
-                            return;
+                           String::new()
                         }
                     }
                 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,29 +1,35 @@
 use std::env;
 use std::path::PathBuf;
 use std::process::Command;
+use temp_dir::TempDir;
 mod common;
 
 #[tokio::test]
 async fn test_cli() {
-    common::setup().await;
+    // TempDir deletes the created directory when the struct is dropped. Call TempDir::leak() to
+    // keep it around for debugging purposes.
+    let tmpdir = &TempDir::new().unwrap();
+    common::setup(tmpdir).await;
 
     let target_dir = env::var("CARGO_MANIFEST_DIR").expect("could not get target dir");
-    let mut current_dir = env::current_dir().expect("could not get current dir");
-    current_dir.push(common::BASE_DIR);
 
     let mut path = PathBuf::from(target_dir);
-
     path.push("target/release/lyricsrs");
+
     let output = Command::new(path)
-        .arg(current_dir)
+        .arg(tmpdir.path())
         .output()
         .expect("Failed to execute command");
 
-    println!("{:?}", output);
+    let stdout_str = String::from_utf8_lossy(&output.stdout);
+    let stderr_str = String::from_utf8_lossy(&output.stderr);
+
+    println!("Exit code: {}", output.status.code().unwrap());
+    println!("STDOUT: {}", stdout_str);
+    println!("STDERR: {}", stderr_str);
 
     assert!(output.status.success());
 
-    let stdout_str = String::from_utf8_lossy(&output.stdout);
     // keep in sync with SONGS in common/mod.rs
     let to_find = format!(
         "Successful tasks: {}\nFailed tasks: 0\nTotal tasks: {}",
@@ -32,7 +38,43 @@ async fn test_cli() {
     );
     assert!(stdout_str.contains(&to_find));
 
-    assert!(common::check_lrcs().await);
+    assert!(common::check_lrcs(tmpdir).await);
+}
 
-    common::cleanup().await;
+#[tokio::test]
+async fn test_cli_plain_lyrics_allowed() {
+    // TempDir deletes the created directory when the struct is dropped. Call TempDir::leak() to
+    // keep it around for debugging purposes.
+    let tmpdir = &TempDir::new().unwrap();
+    common::setup(tmpdir).await;
+
+    let target_dir = env::var("CARGO_MANIFEST_DIR").expect("could not get target dir");
+
+    let mut path = PathBuf::from(target_dir);
+    path.push("target/release/lyricsrs");
+
+    let output = Command::new(path)
+        .arg("--allow-plain")
+        .arg(tmpdir.path())
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout_str = String::from_utf8_lossy(&output.stdout);
+    let stderr_str = String::from_utf8_lossy(&output.stderr);
+
+    println!("Exit code: {}", output.status.code().unwrap());
+    println!("STDOUT: {:?}", stdout_str);
+    println!("STDERR: {:?}", stderr_str);
+
+    assert!(output.status.success());
+
+    // keep in sync with SONGS in common/mod.rs
+    let to_find = format!(
+        "Successful tasks: {}\nFailed tasks: 0\nTotal tasks: {}",
+        common::SONGS.len(),
+        common::SONGS.len()
+    );
+    assert!(stdout_str.contains(&to_find));
+
+    assert!(common::check_lrcs(tmpdir).await);
 }


### PR DESCRIPTION
Allow the option to use plain lyrics if synced aren't available. They can be fed into a LRC generator for making proper synced lyrics, and for some people plain lyrics is better than no lyrics.

Changes the CLI parser to `clap` to make it easier to declare flags and parse the ways someone might pass them. Keeps the existing behaviour as default (`lyricsrs /path/to/music/dir` works and skips plain lyrics) and adds the `--allow-plain` CLI flag to tell `lyricsrs` to write plain lyrics if that's all that's available.